### PR TITLE
Add http2 to virtual servers

### DIFF
--- a/ubuntu/oui/config/domain.com.conf
+++ b/ubuntu/oui/config/domain.com.conf
@@ -1,7 +1,7 @@
 listen 80;
 listen [::]:80;
-listen 443 ssl;
-listen [::]:443 ssl;
+listen 443 ssl http2;
+listen [::]:443 ssl http2;
 include config/cf.conf;
 #access_log     /var/log/nginx/nginx.DOMAIN.access.log;
 #error_log      /var/log/nginx/nginx.DOMAIN.error.log;


### PR DESCRIPTION
Xenial provides nginx version 1.10.x: https://packages.ubuntu.com/xenial/nginx

nginx support http2 since 1.9.5: 
```The http2 parameter (1.9.5) configures the port to accept HTTP/2 connections. Normally, for this to work the ssl parameter should be specified as well, but nginx can also be configured to accept HTTP/2 connections without SSL.```