### PR TITLE
Automatically add Windows Firewall Rules

### DIFF
--- a/windows/o2wi/o2wi_installer.bat
+++ b/windows/o2wi/o2wi_installer.bat
@@ -309,6 +309,18 @@ SET /p "=PHP   status : " <nul
 NSSM status PHP
 ECHO.
 
+ECHO.
+ECHO #########################################
+ECHO CREATE WINDOWS FIREWALL RULE
+ECHO #########################################
+ECHO.
+ECHO ADDING RULE FOR PORT 80
+netsh advfirewall firewall add rule name="Organizr - HTTP" dir=in action=allow protocol=TCP localport=80
+IF "%ssl_site%"=="y" (
+ECHO ADDING RULE FOR PORT 443
+netsh advfirewall firewall add rule name="Organizr - HTTPS" dir=in action=allow protocol=TCP localport=443
+)
+
 IF "%ssl_site%"=="y" ( 
 ECHO.
 ECHO #########################################

--- a/windows/o2wi/owi_uninstaller.bat
+++ b/windows/o2wi/owi_uninstaller.bat
@@ -57,6 +57,12 @@ RMDIR /s /q c:\nginx >nul 2>&1
 ECHO.Done!
 ECHO.
 
+ECHO 6. Removing Firewall Rules
+netsh advfirewall firewall delete rule name="Organizr - HTTP"
+netsh advfirewall firewall delete rule name="Organizr - HTTPS"
+ECHO.Done!
+ECHO.
+
 rem DEL /s /q c:\Windows\System32\nssm.exe >nul 2>&1
 
 pause


### PR DESCRIPTION
Added to the script to add two firewall rules - one for port 80 and one for port 443 (only if yes is selected for SSL). Also added to the uninstaller to delete the two rules. I tested this out with another program controlling the firewall and it doesn't seem to care. On removal, it will just say that there is no match (like if the rule for HTTPS wasn't created).