### PR TITLE
owi: ssl conf update

### DIFF
--- a/windows/owi/config/nginx-ssl.conf
+++ b/windows/owi/config/nginx-ssl.conf
@@ -23,10 +23,9 @@ http {
 	}
     }
     server {
-        listen       443;
+        listen 443 ssl;
 	#CHANGE THESE LINES##########
         server_name  [domain_name] localhost;
-	#DISABLED ssl on;
 	#DISABLED ssl_certificate C:\ProgramData\win-acme\httpsacme-v01.api.letsencrypt.org\[domain_name]-chain.pem;
 	#DISABLED ssl_certificate_key C:\ProgramData\win-acme\httpsacme-v01.api.letsencrypt.org\[domain_name]-key.pem;
 	#DISABLED ssl_trusted_certificate C:\ProgramData\win-acme\httpsacme-v01.api.letsencrypt.org\[domain_name]-crt.pem;


### PR DESCRIPTION
Removed ssl on; deprecated directive.
Use listen 443 ssl; instead